### PR TITLE
Fix: Bad Title.path in Multilanguage sites if parent slug is created …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 
 * Fixed builds on RTD
 * Enforce use of coverage > 4 for python 3.8 support
+* Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
 
 3.8.0 (2020-10-28)
 ==================

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -472,8 +472,9 @@ class ChangePageForm(BasePageForm):
 
         if update_count == 0:
             api.create_title(language=self._language, page=cms_page, **translation_data)
-        else:
-            cms_page._update_title_path_recursive(self._language)
+        # _update_title_path_recursive should be called if the new page is the parent
+        # of already created children in multilingual sites.
+        cms_page._update_title_path_recursive(self._language, slug=self.data['slug'])
         cms_page.clear_cache(menu=True)
         return cms_page
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -340,7 +340,7 @@ class Page(models.Model):
         title_obj.path = title_obj.get_path_for_base(base)
         title_obj.save()
 
-    def _update_title_path_recursive(self, language):
+    def _update_title_path_recursive(self, language, slug=None):
         assert self.publisher_is_draft
         from cms.models import Title
 
@@ -348,7 +348,10 @@ class Page(models.Model):
             return
 
         pages = self.get_child_pages()
-        base = self.get_path(language, fallback=True)
+        if slug:
+            base = self.get_path_for_slug(slug, language)
+        else:
+            base = self.get_path(language, fallback=True)
 
         if base:
             new_path = Concat(models.Value(base), models.Value('/'), models.F('slug'))

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -1138,6 +1138,56 @@ class PagesTestCase(TransactionCMSTestCase):
             self.assertContains(resp, public_text)
             self.assertNotContains(resp, draft_text)
 
+    def test_translated_subpage_title_path_regeneration(self):
+        """
+        When a child page is created with multiple translations before parent translation,
+        child title translation path should be regenerated to take into account parent path.
+
+        This test enforces the issues found in: https://github.com/django-cms/django-cms/issues/6622,
+        where the slug was not regenerated.
+        """
+        parent = create_page('en-parent', "nav_playground.html", 'en',
+                             slug = 'en-parent', published=True)
+        child = create_page('en-child', "nav_playground.html", 'en',
+                            slug = 'en-child', parent=parent, published=True)
+        
+        create_title('de', 'de-child', child, slug='de-child')
+
+        # Parent 'de' title created after child translation
+        create_title('de', 'de-parent', parent, slug='de-parent')
+        parent._update_title_path_recursive('de', slug='de-parent')
+        parent.clear_cache(menu=True)
+
+        parent.publish('de')
+        child.publish('de')
+
+        response = self.client.get('/de/de-parent/de-child/')
+        self.assertEqual(response.status_code, 200)
+
+    def  test_subpage_title_path_regeneration_after_parent_slug_change(self):    
+        """
+        When a parent page slug changes,
+        the child title path should be regenerated.
+        
+        This test enforces the issues found in: https://github.com/django-cms/django-cms/issues/6622,
+        where the slug was not regenerated.
+        """
+        parent = create_page('BadFoo', "nav_playground.html", 'en',
+                             slug = 'badfoo', published=True)
+        child = create_page('Bar', "nav_playground.html", 'en',
+                            slug = 'bar', parent=parent, published=True)
+        title = parent.get_title_obj(language='en', fallback=False)
+        title.title='Foo'
+        title.save()
+        parent._update_title_path_recursive('en', slug='foo')
+        parent.clear_cache(menu=True)
+
+        parent.publish('en')
+        child.publish('en')
+
+        response = self.client.get('/en/foo/bar/')
+        self.assertEqual(response.status_code, 200)
+
 
 class PageTreeTests(CMSTestCase):
 


### PR DESCRIPTION
…or modified (#6968)

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop``
* [ ] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
